### PR TITLE
add suggested models

### DIFF
--- a/pages/assistant/configuration.mdx
+++ b/pages/assistant/configuration.mdx
@@ -9,7 +9,12 @@ import { CustomCallout } from '@components/custom-callout';
 
 # Assistant configuration
 
-When you deploy MOSTLY AI, the Assistant is included as part of the deployment of Kubernetes services and containers. For the Assistant to work, you need to configure access to the Large Language Model (LLM). The Assistant can use any LLM provided by your organization.
+When you deploy MOSTLY AI, the Assistant is included as part of the deployment of Kubernetes services and containers. For the Assistant to work, you need to configure access to the Large Language Model (LLM).
+
+The Assistant can use any LLM provided by your organization but MOSTLY AI recommends the following models:
+
+- [Claude Sonnet 4.5](https://docs.litellm.ai/docs/providers/anthropic#supported-models-1) from Anthropic
+- [GPT-4.1](https://docs.litellm.ai/docs/providers/openai#supported-models-1) from OpenAI
 
 <CustomCallout>**Note**: You can only configure the Assistant as a **Super Admin**.</CustomCallout>
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds recommended LLM models (Claude Sonnet 4.5, GPT-4.1) to the Assistant configuration docs.
> 
> - **Docs**:
>   - Update `pages/assistant/configuration.mdx` to recommend specific LLMs with links:
>     - `Claude Sonnet 4.5` (Anthropic)
>     - `GPT-4.1` (OpenAI)
>   - Remove prior generic statement about using any org-provided LLM.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 749b0e359f87c58af5db8937d43c52e47229416f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->