### PR TITLE
ci(chart): Update action versions in workflows for stability

### DIFF
--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -16,31 +16,31 @@ jobs:
       id-token: write
     steps:
       - name: Setup | Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with: {fetch-depth: 1}
 
       - name: Setup | Docker Buildx
-        uses: docker/setup-buildx-action@v3.10.0
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
         with:
           cache-binary: false
           cleanup: false
           platforms: ${{ env.PLATFORMS }}
 
       - name: Setup | Docker Build Metadata
-        uses: docker/metadata-action@v5.7.0
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v.5.10.0
         id: meta
         with:
           images: ghcr.io/mostly-ai/docs
 
       - name: Setup | Docker Login
-        uses: docker/login-action@v3.4.0
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build | Build Docker Image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
         env:
           DOCKER_BUILD_RECORD_UPLOAD: 'false'
           BUILDX_NO_DEFAULT_ATTESTATIONS: '1'
@@ -54,7 +54,7 @@ jobs:
           sbom: true
 
       - name: Build | Generate SBOM
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
         with:
           image: ${{ steps.meta.outputs.tags }}
           format: cyclonedx-json

--- a/.github/workflows/lint-check.yaml
+++ b/.github/workflows/lint-check.yaml
@@ -14,10 +14,10 @@ jobs:
       contents: read
     steps:
       - name: Setup | Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with: {fetch-depth: 1}
 
       - name: Build | Pre-Commit Check
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
           extra_args: --all-files


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Pins actions to commit SHAs and updates versions across Docker build and lint workflows.
> 
> - **Workflows**:
>   - **`/.github/workflows/build-docker-image.yaml`**:
>     - Update `actions/checkout` to `v6.0.1` (pinned SHA).
>     - Update `docker/setup-buildx-action` to `v3.11.1` (pinned SHA).
>     - Update `docker/metadata-action` to `v5.10.0` (pinned SHA).
>     - Update `docker/login-action` to `v3.6.0` (pinned SHA).
>     - Update `docker/build-push-action` to `v6.18.0` (pinned SHA).
>     - Update `anchore/sbom-action` to `v0.20.10` (pinned SHA).
>   - **`/.github/workflows/lint-check.yaml`**:
>     - Update `actions/checkout` to `v6.0.1` (pinned SHA).
>     - Pin `pre-commit/action` to SHA for `v3.0.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c087acf9fdcb598bb0d91dce33febea6b35c638f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->