### PR TITLE
Release 5.8.2

### DIFF
--- a/pages/concepts/what-are-credits.mdx
+++ b/pages/concepts/what-are-credits.mdx
@@ -11,7 +11,7 @@ MOSTLY AI’s credit system is designed to give you transparency, flexibility, a
 
 In short, credits are the currency used by the MOSTLY AI Platform and the MOSTLY AI Asisstant. Anytime you create [synthetic data](/synthetic-dataa) with a [generator](/generators) or ask the [Assistant](/assisstant) to do something like provide information or generate a visualization, you consume a small number of credits depending on the complexity and size of the request or task.
 
-Users on the **Free Plan** receive **5 new credits every day**, which is enough to power meaningful experimentation and exploration. Heavier usage or more complex tasks may require purchasing additional credits or upgrading to a [paid plan](https://mostly.ai/pricing#plans).
+Users on the **Free tier** receive **2 new credits every day**, which is enough to power meaningful experimentation and exploration. Heavier usage or more complex tasks may require purchasing additional credits—[contact MOSTLY AI](https://mostly.ai/contact) to tailor limits for your organization.
 
 ## What are tokens?
 
@@ -27,8 +27,8 @@ Think of tokens as the raw materials the Assistant uses to generate synthetic ve
 
 There are a few easy ways to get more credits:
 
-- **Daily top-up**: Every Free tier user receives 5 new credits each day, automatically.
-- **Paid plans**: Upgrade your workspace to get higher daily limits.
+- **Daily top-up**: Every Free tier user receives 2 new credits each day, automatically.
+- **Talk to us**: Reach out to MOSTLY AI if you need higher daily limits or custom usage.
 
 ## How can I conserve credits?
 

--- a/pages/usage.mdx
+++ b/pages/usage.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Usage and credits'
-description: 'Daily, MOSTLY AI provides 5 credits for the free generation of synthetic data points. 1 credits equals 1 million synthetic data points. 5 credits equals 1 million chat tokens.'
+description: 'Daily, MOSTLY AI provides 2 credits for the free generation of synthetic data points. 1 credit equals 1 million synthetic data points. 5 credits equals 1 million chat tokens.'
 ---
 
 import { Tabs } from 'nextra/components';
@@ -9,7 +9,7 @@ import { CustomCallout } from '@components/custom-callout';
 
 # Usage and credits
 
-The [MOSTLY AI Platform](https://app.mostly.ai) provides a daily limit of 5 credits to train generators, generate synthetic datasets, and use the [Assistant](./assistant.mdx). Enterprise deployments have a usage-based configuration which can be adjusted according to the organization's needs.
+The [MOSTLY AI Platform](https://app.mostly.ai) provides a daily limit of 2 credits to train generators, generate synthetic datasets, and use the [Assistant](./assistant.mdx). Enterprise deployments have a usage-based configuration which can be adjusted according to the organization's needs.
 
 <CustomCallout>
 **Note**
@@ -44,7 +44,7 @@ GPU time is only available when a GPU was selected to generate the synthetic dat
 
 ## Credits
 
-Credits are consumed based on the total virtual CPU and GPU time used to train generators and generate synthetic datasets. Credits are also be consumed during conversation with the Assistant at a rate of 5 credits per 1M tokens.
+Credits are consumed based on the total virtual CPU and GPU time used to train generators and generate synthetic datasets. Credits are also consumed during conversation with the Assistant at a rate of 5 credits per 1M tokens.
 
 `Credits` = `𝐴` × `Total Virtual CPU Time` + `𝐵` × `Total Virtual GPU Time`, where `𝐴` and `𝐵`are the unit prices for CPU and GPU time respectively.
 
@@ -81,7 +81,7 @@ The result is a Python dictionary and you can find details about your current cr
     'usage': {
         'credits': {
             'current': 1.662,
-            'limit': 5.0,
+            'limit': 2.0,
             'period_start': datetime.datetime(2024, 4, 18, 0, 0, tzinfo=TzInfo(UTC)),
             'period_end': datetime.datetime(2024, 4, 18, 23, 59, 59, 999999, tzinfo=TzInfo(UTC))
         },

--- a/pages/whats-new.mdx
+++ b/pages/whats-new.mdx
@@ -16,13 +16,6 @@ import Image from 'next/image';
 
 - {/* MSD-XXXX */} Fix ordering of the Artifacts page.
 
-### Misc (Internal)
-
-- {/* MSD-XXXX */} Add stricter email validation for user signups by blocking burner domains and addresses that include `+`.
-- {/* MSD-XXXX */} Reduce the daily credit limit for Free users from 5 to 2.
-- {/* MSD-XXXX */} Disable the PRO plan.
-- {/* MSD-XXXX */} Stop sending `artifact_image` content to LLM endpoints to reduce token usage.
-
 ## 5.8.1
 
 ### Resolved Issues

--- a/pages/whats-new.mdx
+++ b/pages/whats-new.mdx
@@ -8,6 +8,21 @@ import Image from 'next/image';
 
 # What's new in MOSTLY AI
 
+# What's new in MOSTLY AI
+
+## 5.8.2
+
+### Resolved issues
+
+- {/* MSD-XXXX */} Fix ordering of the Artifacts page.
+
+### Misc (Internal)
+
+- {/* MSD-XXXX */} Add stricter email validation for user signups by blocking burner domains and addresses that include `+`.
+- {/* MSD-XXXX */} Reduce the daily credit limit for Free users from 5 to 2.
+- {/* MSD-XXXX */} Disable the PRO plan.
+- {/* MSD-XXXX */} Stop sending `artifact_image` content to LLM endpoints to reduce token usage.
+
 ## 5.8.1
 
 ### Resolved Issues


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Docs update free-tier daily credits from 5 to 2 and add 5.8.2 release note with an Artifacts ordering fix.
> 
> - **Documentation**
>   - **Credits policy**: Update Free tier allocation from 5 to 2 daily credits in `pages/concepts/what-are-credits.mdx` and `pages/usage.mdx`; add contact link for higher limits.
>   - **Usage examples**: Adjust description, UI text, and SDK example `credits.limit` from `5.0` to `2.0`; minor grammar fix; token rate remains `5 credits / 1M tokens`.
> - **Release notes**
>   - Add `5.8.2` section in `pages/whats-new.mdx` with a resolved issue: fix ordering of the Artifacts page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9508e247732548dcb4463adc40bb70887da115c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->