### PR TITLE
ci(build): update image tag to use branch name in workflow

### DIFF
--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -56,5 +56,5 @@ jobs:
       - name: Build | Generate SBOM
         uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
         with:
-          image: ${{ steps.meta.outputs.tags }}
+          image: ghcr.io/mostly-ai/docs:${{ github.ref_name }}
           format: cyclonedx-json


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update workflow to generate SBOM from the branch-tagged image (`ghcr.io/mostly-ai/docs:${{ github.ref_name }}`) instead of metadata-derived tags.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61f73d3ed5c1f5683b3cf53439c67e8f76133642. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->