### PR TITLE
release-notes-591

### DIFF
--- a/pages/whats-new.mdx
+++ b/pages/whats-new.mdx
@@ -18,7 +18,6 @@ import Image from 'next/image';
 
 - {/* MSD-XXX */} Fix UI issue upon disconnecting from a OAuth2 provider on integrations page
 - {/* MSD-2350 */} Increase byte buffer in assistant broker to prevent large file download errors
-- {/* MSD-2336 */} Fix duplicate notifications
 - {/* MSD-XXX */} Fix credit validation logic
 - {/* MSD-2326 */} Fix UI button inconsistencies
 

--- a/pages/whats-new.mdx
+++ b/pages/whats-new.mdx
@@ -8,6 +8,20 @@ import Image from 'next/image';
 
 # What's new in MOSTLY AI
 
+## 5.9.1
+
+### Footer and full page view in shared artifacts
+
+- {/* MSD-2332 */} Sharing Artifacts with MOSTLY AI, just got even better. Now you can view the Artifact in a full page view, and see the footer with all the links to the MOSTLY AI Platform.
+
+### Fixes
+
+- {/* MSD-XXX */} Fix UI issue upon disconnecting from a OAuth2 provider on integrations page
+- {/* MSD-2350 */} Increase byte buffer in assistant broker to prevent large file download errors
+- {/* MSD-2336 */} Fix duplicate notifications
+- {/* MSD-XXX */} Fix credit validation logic
+- {/* MSD-2326 */} Fix UI button inconsistencies
+
 ## 5.9.0
 
 ### Integrations using OAuth to external services


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds 5.9.1 release notes with shared artifact full-page/footer update and multiple fixes to OAuth2 UI, assistant broker buffering, credit validation, and UI buttons.
> 
> - **Docs**:
>   - Update `pages/whats-new.mdx` with **5.9.1** release notes:
>     - **Shared artifacts**: full-page view and footer links (`MSD-2332`).
>     - **Fixes**: OAuth2 disconnect UI (`MSD-XXX`), increase assistant broker byte buffer for large downloads (`MSD-2350`), credit validation logic (`MSD-XXX`), button inconsistencies (`MSD-2326`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd4ab4a6de0836ccb5d00109bcda9db3048a2c50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->